### PR TITLE
Mark the javascript example as deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ Instead of using the browser tool to send queries to BigQuery, you can use code 
 * Try the "getting started" samples in one or more languages by navigating to the subdirectory in this repository for the desired language:
   + [RMarkdown](./RMarkdown)
   + [R](./R)
-  + [JavaScript](./javascript)
 * All languages will require a Project ID from a project that has the BigQuery API enabled.
   + Follow the [BigQuery sign up instructions](https://cloud.google.com/bigquery/sign-up) if you do not yet have a valid project.  (Note: you do not need to enable billing for the small examples in this repository)
   + You can find the Project ID for your new project in the
-  [Google Developers Console](https://console.developers.google.com).
+  [Google Cloud Console](https://console.cloud.google.com).
 
-
+* For more information on accessing BigQuery from other languages, see:
+[Create A Simple Application With the API](https://cloud.google.com/bigquery/create-simple-app-api)

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,5 +1,10 @@
 # Getting started in javascript
 
+| Deprecated |
+|--------------------|
+| This example is deprecated. The Google Genomics v1beta2 API is scheduled for turndown on August 15, 2016. When the API is turned down, this example will cease to function. |
+| For an example of accessing the Google Genomics v1 API from Javascript, see the [Getting Started with the API](https://github.com/googlegenomics/getting-started-with-the-api/) repository. |
+
 1. Javascript requires a client ID in addition to the Project ID you already set up:
 
     1. First select your [BigQuery enabled project](https://console.developers.google.com/project/_/apiui/credential)


### PR DESCRIPTION
Add a pointer to official BigQuery developer docs.